### PR TITLE
validar fecha mínima para crear un evento

### DIFF
--- a/app/(tabs)/(home)/select-event-date.tsx
+++ b/app/(tabs)/(home)/select-event-date.tsx
@@ -28,8 +28,7 @@ const SelectEventDate = observer(() => {
   const [pickerMode, setPickerMode] = useState<"date" | "time">("date");
   const [pickerTarget, setPickerTarget] = useState("");
   const router = useRouter();
-  const { eventStore } = useStores();
-
+  const { eventStore,toastStore} = useStores();
   const { formValues, setFieldValue, handleSubmit, errors } =
     useForm<EventForm>({
       defaultValues: {
@@ -59,6 +58,7 @@ const SelectEventDate = observer(() => {
     });
 
   const handleDateChange = (selectedDate: Date) => {
+    validateDate(selectedDate)
     if (selectedDate) {
       if (pickerTarget === "date") setFieldValue("date", selectedDate as any);
       else if (pickerTarget === "start")
@@ -68,7 +68,26 @@ const SelectEventDate = observer(() => {
     }
     setDatePickerVisibility(false);
   };
+const validateDate=(selectedDate: Date)=>{
+  if (selectedDate) {
+    // Validar si se está seleccionando una fecha anterior a mañana
+    if (pickerTarget === "date") {
+      const tomorrow = new Date();
+      tomorrow.setHours(0, 0, 0, 0);
+      tomorrow.setDate(tomorrow.getDate() + 1);
 
+      const selected = new Date(selectedDate);
+      selected.setHours(0, 0, 0, 0);
+
+      if (selected < tomorrow) {
+        toastStore.addToast("No se puede seleccionar una fecha anterior a mañana", "warning");
+        return;
+      }
+
+
+  }
+}
+}
   const showDatePicker = (
     target: "date" | "start" | "end",
     mode: "date" | "time"

--- a/app/(tabs)/(home)/select-event-date.tsx
+++ b/app/(tabs)/(home)/select-event-date.tsx
@@ -190,7 +190,7 @@ const SelectEventDate = observer(() => {
         isVisible={isDatePickerVisible}
         mode={pickerMode}
         display={Platform.OS === "ios" ? "spinner" : "default"}
-        minimumDate={pickerTarget === "date" ? new Date() : undefined}
+        minimumDate={pickerTarget === "date" ? new Date(new Date().setDate(new Date().getDate() + 1)) : undefined}
         onConfirm={handleDateChange}
         onCancel={() => setDatePickerVisibility(false)}
         locale={pickerMode === "date" ? "es_ES" : undefined}

--- a/app/(tabs)/(home)/shopping-cart.tsx
+++ b/app/(tabs)/(home)/shopping-cart.tsx
@@ -7,6 +7,7 @@ import useShoppingCart from "@/hooks/use-shopping-cart";
 import { ServiceCategory } from "@/interfaces/service-category";
 import { createEvent } from "@/services/events.service";
 import { formatEventDate } from "@/utils/date.utils";
+import { MaterialIcons } from "@expo/vector-icons";
 import { useRouter } from "expo-router";
 import { toJS } from "mobx";
 import { observer } from "mobx-react-lite";
@@ -49,7 +50,12 @@ const ShoppingCart = observer(() => {
     creatingEvent || !hasItems || !eventName || !location;
 
   return (
+    
     <View style={{ flex: 1 }}>
+        <Pressable style={styles.backButton} onPress={() => router.back()}>
+        <MaterialIcons name="arrow-back" size={24} color="black" />
+        <Text style={styles.backText}>Atrás</Text>
+      </Pressable>
       <ScrollView
         contentContainerStyle={styles.container}
         showsVerticalScrollIndicator={false}
@@ -214,6 +220,19 @@ const styles = StyleSheet.create({
     fontWeight: "bold",
     fontSize: 14,
     textAlign: "center",
+  },
+  backButton: {
+    flexDirection: "row",
+    alignItems: "center",
+    marginHorizontal: 10,
+    marginTop: 10,
+    marginBottom: 10,
+  },
+
+  backText: {
+    fontSize: 16,
+    marginLeft: 5,
+    color: "#000",
   },
 });
 

--- a/stores/event-store.ts
+++ b/stores/event-store.ts
@@ -28,7 +28,7 @@ export interface IItemsRecord {
 
 const defaultEvent: IEvent = {
   eventName: "",
-  date: new Date(),
+  date: new Date(new Date().setDate(new Date().getDate() + 1)) ,
   startTime: new Date(),
   endTime: new Date(),
   guestCount: 0,


### PR DESCRIPTION
* se agregó una validación para que la fecha mínima para crear un evento sea un día después del actual, se va a mostrar por defecto la fecha del dia siguiente al actual
<img width="308" alt="image" src="https://github.com/user-attachments/assets/ef3f12be-667f-4c89-b125-ddadb1ee5c6a" />

* se añadio un toast en caso de que se pueda seleccionar fecha actual o anterior
<img width="443" alt="image" src="https://github.com/user-attachments/assets/30ea5a52-34ba-4b79-b054-85a996b1133a" />

* se agregó un boton para devolverse estando en el carrito
<img width="305" alt="image" src="https://github.com/user-attachments/assets/2da31fbb-24bd-4eac-92a6-f3ce40f4334b" />


